### PR TITLE
Move musicConverter endpoint to generic webhookUpdate + bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ export TELEGRAM_TOKEN_PROD=
 export TELEGRAM_ALERT_GROUP=
 
 # helpers for testing calls locally
-export TELEGRAM_API_GATEWAY_ROOT_LOCAL="localhost:3000/telegram"
+export TELEGRAM_API_GATEWAY_ROOT_LOCAL="localhost:3000"
 export TELEGRAM_API_GATEWAY_ROOT_DEV="https://$BOT_DOMAIN_DEV"
 export TELEGRAM_API_GATEWAY_ROOT_PROD="https://$BOT_DOMAIN_PROD"
 
@@ -263,6 +263,12 @@ $ pipenv run python {file}.py
 ### Telegram bot alert
 ```
 $ curl --header "Content-Type: application/json" --request POST --data '{"alerter": "user"}' $TELEGRAM_API_GATEWAY_ROOT_LOCAL/alert
+```
+
+### Music link
+
+```
+curl --tlsv1.2 -v -k -H "Content-Type: application/json" -H "Cache-Control: no-cache"  -d '{"update_id":10000, "message":{ "date":99999999999, "chat":{ "last_name":"Test Lastname", "id":1111111, "first_name":"Test", "username":"Test" }, "message_id":1365, "from":{ "last_name":"Test Lastname", "id":1111111, "first_name":"Test", "username":"Test" }, "text":"https://open.spotify.com/track/43ddJFnP8m3PzNJXiHuiyJ?si=T3ZApBErTF-M1esGJoRMmw" } }' $TELEGRAM_API_GATEWAY_ROOT_LOCAL/webhookUpdate
 ```
 
 ## Better Logging and Maintenance

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ export TELEGRAM_API_GATEWAY_ROOT_DEV="https://u3ir5tjcsf.execute-api.us-east-1.a
 
 ## Adding a New Endpoint
 
-If you want to extend the functionality of the bot with your own requests/commands, it is recommend you move it to a new endpoint.
+If you want to extend the functionality of the bot with your own requests/commands, you need to create a new endpoint.
 
 1. Add endpoint to serverless.yml.
 
@@ -217,6 +217,10 @@ If you want to extend the functionality of the bot with your own requests/comman
   elif event['path'] == "/myEndpoint":
       return {"statusCode": 400}  # not yet available
   ```
+
+### Adding new webhookUpdate parser
+
+All webhook updates currently go to the `webhookUpdate/` endpoint. Update `handle_webhook_update()` in handler.py with your new message-parsing logic. Make sure you consider how this will interact with other tools that are looking to parse messages.
 
 ## Tailing Logs
 

--- a/handler.py
+++ b/handler.py
@@ -61,12 +61,12 @@ def telegram_music_converter(event, context):
     event_body = json.loads(event['body'])
 
     try:
-        msg = event_body['message']['text']
+        text = event_body['message']['text']
     except KeyError:
         logging.error("Parsing message from Telegram update")
         return {"statusCode": 400}
 
-    urls = urls_in_message(msg)
+    urls = urls_in_text(text)
     if not urls:
         return {"statusCode": 200}
 
@@ -85,9 +85,9 @@ def telegram_music_converter(event, context):
 Helpers
 """
 
-def send_message(msg, chat_id):
+def send_message(text, chat_id):
     try:
-        data = {"text": msg.encode("utf8"), "chat_id": chat_id}
+        data = {"text": text.encode("utf8"), "chat_id": chat_id}
         url = BASE_URL + "/sendMessage"
     except Exception as e:
         logging.error("Encoding message", exc_info=True)
@@ -106,8 +106,8 @@ def send_message(msg, chat_id):
 
     return {"statusCode": 200}
 
-def urls_in_message(msg):
-    urls = [w for w in msg.split(' ') if re.match('http[s]?://.*', w)]
+def urls_in_text(text):
+    urls = [w for w in text.split(' ') if re.match('http[s]?://.*', w)]
     return urls
 
 def get_similar_tracks_from_urls(urls):
@@ -146,7 +146,7 @@ def get_similar_tracks_for_original_track(track_svc, original_track):
 
 if __name__ == '__main__':
     # Integration Tests
-    msg = """
+    text = """
     Hey! Check out these tracks!
     https://open.spotify.com/track/43ddJFnP8m3PzNJXiHuiyJ?si=T3ZApBErTF-M1esGJoRMmw
     https://youtu.be/_kvZpVMY89c
@@ -170,7 +170,7 @@ if __name__ == '__main__':
                     'first_name': 'Test',
                     'username': 'Test'
                 },
-                'text': msg
+                'text': text
             }
         }
     )}

--- a/handler.py
+++ b/handler.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import os
@@ -33,7 +34,8 @@ def handler(event, context):
             return send_alert(event, context)
         elif event['path'] == "/webhookUpdate":
             return handle_webhook_update(event, context)
-    except Exception:
+    except Exception as e:
+        logging.error("Handling request", exc_info=True)
         return {"statusCode": 500}
     return {"statusCode": 404}
 
@@ -61,9 +63,23 @@ def handle_webhook_update(event, context):
     event_body = json.loads(event['body'])
 
     try:
+        msg_date = event_body['message']['date']
+    except KeyError:
+        logging.error("Parsing date from Telegram update")
+        return {"statusCode": 400}
+
+    # avoid spamming our APIs
+    timeout = 30  # seconds
+    age = datetime.datetime.now().timestamp() - msg_date
+    logging.info(f"Telegram update age: {age}s")
+    if age > timeout:
+        logging.info(f"Ignoring old Telegram update")
+        return {"statusCode": 200}
+
+    try:
         text = event_body['message']['text']
     except KeyError:
-        logging.error("Parsing message from Telegram update")
+        logging.error("Parsing text from Telegram update")
         return {"statusCode": 400}
 
     urls = urls_in_text(text)
@@ -81,7 +97,10 @@ Webhook Update Parsers
 def send_music_mirror_links(urls):
     similar_tracks = get_similar_tracks_from_urls(urls)
     if not similar_tracks:
+        logging.info("No mirrors found for url")
         return {"statusCode": 200}
+
+    logging.info(f"similar_tracks: {similar_tracks}") #TODO rm
 
     response = "Mirrors:\n"
     for idx, track_matches in enumerate(similar_tracks):
@@ -121,17 +140,20 @@ def urls_in_text(text):
 
 def get_similar_tracks_from_urls(urls):
     similar_tracks: List[Dict[str, StreamingServiceTrack]] = []
+    logging.info(f"urls: {urls}") #TODO rm
     for url in urls:
         logging.info("URL detected")
         logging.info(url)
         svc = get_streaming_service_for_url(url)
         if svc:
             trackId = svc.get_trackId_from_url(url)
+            logging.info(f"url: {url} ; trackId: {trackId}") #TODO rm
             try:
                 with svc() as svc_client:
                     original_track = svc_client.get_track_from_trackId(trackId)
             except Exception as e:
                 logging.error("Getting track from track id", exc_info=True)
+                continue
             similar_tracks.append(get_similar_tracks_for_original_track(svc, original_track))
         else:
             logging.info("URL is not for a supported streaming service")

--- a/handler.py
+++ b/handler.py
@@ -100,8 +100,7 @@ def send_music_mirror_links(urls):
         logging.info("No mirrors found for url")
         return {"statusCode": 200}
 
-    logging.info(f"similar_tracks: {similar_tracks}") #TODO rm
-
+    logging.info(f"similar_tracks: {similar_tracks}")
     response = "Mirrors:\n"
     for idx, track_matches in enumerate(similar_tracks):
         if idx != 0:
@@ -140,14 +139,14 @@ def urls_in_text(text):
 
 def get_similar_tracks_from_urls(urls):
     similar_tracks: List[Dict[str, StreamingServiceTrack]] = []
-    logging.info(f"urls: {urls}") #TODO rm
+    logging.info(f"urls: {urls}")
     for url in urls:
         logging.info("URL detected")
         logging.info(url)
         svc = get_streaming_service_for_url(url)
         if svc:
             trackId = svc.get_trackId_from_url(url)
-            logging.info(f"url: {url} ; trackId: {trackId}") #TODO rm
+            logging.info(f"url: {url} ; trackId: {trackId}")
             try:
                 with svc() as svc_client:
                     original_track = svc_client.get_track_from_trackId(trackId)

--- a/handler.py
+++ b/handler.py
@@ -35,7 +35,7 @@ def handler(event, context):
             return handle_webhook_update(event, context)
     except Exception:
         return {"statusCode": 500}
-    return {"statusCode": 400}
+    return {"statusCode": 404}
 
 """
 Endpoint Handlers

--- a/serverless.yml
+++ b/serverless.yml
@@ -20,7 +20,7 @@ functions:
           method: post
           cors: true
       - http:
-          path: musicConverter
+          path: webhookUpdate
           method: post
           cors: true
 

--- a/streaming/google.py
+++ b/streaming/google.py
@@ -49,9 +49,8 @@ class YouTubeTrack(StreamingServiceTrack):
 
 class YouTube(StreamingService):
     VALID_TRACK_URL_PATTERNS = [
-        "https://www.youtube.com/watch\\?v=(?P<trackId>\w+).*",
-        "https://www.youtu.be/(?P<trackId>\w+).*",
-        "https://youtu.be/(?P<trackId>\w+).*",
+        'https://www.youtube.com/watch\?v=(?P<trackId>[A-Za-z0-9\\-\\_]+).*',
+        'https://(www.)?youtu.be/(?P<trackId>[A-Za-z0-9\\-\\_]+).*',
     ]
 
     def __init__(self):
@@ -159,6 +158,7 @@ class GMusic(StreamingService):
 
 if __name__ == "__main__":
     """Unit Tests"""
+    assert YouTube.supports_track_url("https://www.youtube.com/watch?v=GWOIDN-akrY")  # supports dashes
     assert YouTube.supports_track_url("https://www.youtube.com/watch?v=9_gkpYORQLU")
     assert YouTube.supports_track_url("https://www.youtube.com/watch?v=9_gkpYORQLU?t=4")
     assert not YouTube.supports_track_url("https://www.youtube.com/")
@@ -169,6 +169,7 @@ if __name__ == "__main__":
     assert GMusic.supports_track_url("https://play.google.com/music/m/T2y24nzjhuyvlolsptj7zqon5qi?t=GOAT_-_Polyphia")
     assert not GMusic.supports_track_url("https://play.google.com/music/m/")
 
+    assert YouTube.get_trackId_from_url("https://www.youtube.com/watch?v=GWOIDN-akrY"), "GWOIDN-akrY"  # supports dashes
     assert YouTube.get_trackId_from_url("https://www.youtube.com/watch?v=9_gkpYORQLU?t=4"), "9_gkpYORQLU"
     assert YouTube.get_trackId_from_url("https://www.youtu.be/9_gkpYORQLU?t=4"), "9_gkpYORQLU"
     assert GMusic.get_trackId_from_url("https://play.google.com/music/m/T2y24nzjhuyvlolsptj7zqon5qi?t=GOAT_-_Polyphia"), "T2y24nzjhuyvlolsptj7zqon5qi"

--- a/streaming/google.py
+++ b/streaming/google.py
@@ -28,6 +28,12 @@ class MemoryCache(Cache):
 
 
 class YouTubeTrack(StreamingServiceTrack):
+    # Regexp to exclude from searchable video names
+    SEARCHABLE_EXCLUDE_EXPRESSIONS = [
+        r'\s(lyrics|with lyrics)$',
+        r'(\[|\()(Official\s)?(Music\s)?(Video|Movie)(\]|\))',
+    ]
+
     name = None
     artist = None
     id = None
@@ -39,8 +45,10 @@ class YouTubeTrack(StreamingServiceTrack):
 
     @property
     def searchable_name(self):
-        # Remove mentioning of lyrics from the video title
-        searchable_name = re.sub(r'\s(lyrics|with lyrics)$', '', self.name, flags=re.IGNORECASE)
+        searchable_name = self.name
+        # Remove terms that could negatively impact our search on other platforms
+        for exp in self.SEARCHABLE_EXCLUDE_EXPRESSIONS:
+            searchable_name = re.sub(exp, '', searchable_name, flags=re.IGNORECASE)
         return searchable_name
 
     def share_link(self):


### PR DESCRIPTION
Bugfixes:
- Return 404 instead of 400 on bad endpoint call
- Ignore old telegram updates (to avoid spamming APIs)
- Fix YouTube not parsing dashes in videoIds
- Fix bot returning no mirrors if one service returns no result
- Fix search for YouTube titles with variations of "official", i.e. "(Official Music Video)"