### PR TITLE
Use channel name if artist not provided in yt video name

### DIFF
--- a/streaming/tests/integ/test_integ_match.py
+++ b/streaming/tests/integ/test_integ_match.py
@@ -52,6 +52,10 @@ def test_get_similar_track_for_original_track():
     _assert_matches_all_services(
         YouTube, "Bon Iver - PDLIF - Official Video", "Bon Iver"
     )
+    # Video actually separates title and artist
+    _assert_matches_all_services(
+        YouTube, "Patterns (Demo)", "Letters To The Editor - Topic"
+    )
 
     # YTMusic
 


### PR DESCRIPTION
Sometimes the artist name is actually in the yt channel name. Let's leverage this for better matches.