### PR TITLE
Swap artist - title, and other transient index fix

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -108,6 +108,7 @@ def handle_webhook_update(event, context):
             "body": "Could not parse text from Telegram update",
         }
 
+    # handle music search
     search_track = match.search_track_in_text(TELEGRAM_BOT_NAME, text)
     if search_track:
         similar_tracks = match.get_similar_tracks_for_original_track(

--- a/streaming/match.py
+++ b/streaming/match.py
@@ -31,8 +31,8 @@ class SearchTrack(YouTubeTrack):
     and track from a single title. We abuse that fact here to avoid rewriting logic.
     """
 
-    def __init__(self, title, *argv):
-        super().__init__(title, None, None)
+    def __init__(self, artist, title, *argv):
+        super().__init__(artist, title, None)
 
     def share_link(self):
         raise NotImplementedError(
@@ -49,7 +49,7 @@ def search_track_in_text(telegram_bot_name, text):
         return None
 
     title = match.group("title")
-    return SearchTrack(title)
+    return SearchTrack(None, title)
 
 
 SEARCH_NOT_FOUND_MESSAGES = [

--- a/streaming/service/spotify.py
+++ b/streaming/service/spotify.py
@@ -53,13 +53,13 @@ def request_token():
 
 
 class SpotifyTrack(StreamingServiceTrack):
-    title = None
     artist = None
+    title = None
     id = None
 
-    def __init__(self, title, artist, trackId, url=None):
-        self.title = title
+    def __init__(self, artist, title, trackId, url=None):
         self.artist = artist
+        self.title = title
         self.id = trackId
         self.url = url
 
@@ -97,7 +97,7 @@ class Spotify(StreamingService):
         content = json.loads(response.content)
         if content:
             return SpotifyTrack(
-                content["name"], content["artists"][0]["name"], trackId
+                content["artists"][0]["name"], content["name"], trackId
             )
         else:
             return None
@@ -126,8 +126,8 @@ class Spotify(StreamingService):
         tracks = []
         for search_result in search_results["tracks"]["items"]:
             track = SpotifyTrack(
-                search_result["name"],
                 search_result["artists"][0]["name"],  # best guess
+                search_result["name"],
                 search_result["id"],
                 search_result["external_urls"]["spotify"],
             )

--- a/streaming/service/youtube.py
+++ b/streaming/service/youtube.py
@@ -33,15 +33,15 @@ class YouTubeTrack(StreamingServiceTrack):
     # Symbols that may lie between an artist and track title
     SEARCHABLE_NAME_DIVIDERS = {"-", "|", "»"}
 
-    title = None
     artist = None
+    title = None
     id = None
 
-    def __init__(self, title, artist, id):
-        self.title = title
+    def __init__(self, artist, title, id):
         self.artist = (
             artist or ""  # YouTube does not always provide artist information
         )
+        self.title = title
         self.id = id
 
     def share_link(self):
@@ -52,7 +52,7 @@ class YouTubeTrack(StreamingServiceTrack):
     def searchable_name(self):
         """Returns a name that can be used to search against other services"""
         if self.artist and self.artist.endswith("- Topic"):
-            return f"{self.cleaned_title.lower()} - {self.artist[:-7].lower()}"
+            return f"{self.artist[:-7].lower()} - {self.cleaned_title.lower()}"
 
         return self.cleaned_title.lower()
 
@@ -131,8 +131,8 @@ class YouTube(StreamingService):
             return None
         query_result = query_response["items"][0]
         track = YouTubeTrack(
-            query_result["snippet"]["title"],
             query_result["snippet"]["channelTitle"],  # best guess
+            query_result["snippet"]["title"],
             query_result["id"],
         )
         return track
@@ -153,8 +153,8 @@ class YouTube(StreamingService):
         for search_result in search_response.get("items", []):
             if search_result["id"]["kind"] == "youtube#video":
                 track = YouTubeTrack(
-                    search_result["snippet"]["title"],
                     search_result["snippet"]["channelTitle"],  # best guess
+                    search_result["snippet"]["title"],
                     search_result["id"]["videoId"],
                 )
                 tracks.append(track)

--- a/streaming/service/ytmusic.py
+++ b/streaming/service/ytmusic.py
@@ -94,8 +94,11 @@ class YTMusic(StreamingService):
         tracks = []
         for search_result in self._ytmusic_client.search(q, filter="songs"):
             track = search_result
-            ytm_track = YTMusicTrack(
-                track["artists"][0]["name"], track["title"], track["videoId"]
-            )
+
+            # sometimes no artist set
+            artist = track["artists"][0]["name"] if track["artists"] else None
+
+            ytm_track = YTMusicTrack(artist, track["title"], track["videoId"])
             tracks.append(ytm_track)
+
         return tracks

--- a/streaming/service/ytmusic.py
+++ b/streaming/service/ytmusic.py
@@ -32,13 +32,13 @@ class YTMusicTrack(StreamingServiceTrack):
     into a different base class later.
     """
 
-    title = None
     artist = None
+    title = None
     id = None
 
-    def __init__(self, title, artist, id):
-        self.title = title
+    def __init__(self, artist, title, id):
         self.artist = artist
+        self.title = title
         self.id = id
 
     def share_link(self):
@@ -82,8 +82,8 @@ class YTMusic(StreamingService):
             return None
         query_result = query_response["items"][0]
         track = YTMusicTrack(
-            query_result["snippet"]["title"],
             query_result["snippet"]["channelTitle"],  # best guess
+            query_result["snippet"]["title"],
             query_result["id"],
         )
         return track
@@ -95,7 +95,7 @@ class YTMusic(StreamingService):
         for search_result in self._ytmusic_client.search(q, filter="songs"):
             track = search_result
             ytm_track = YTMusicTrack(
-                track["title"], track["artists"][0]["name"], track["videoId"]
+                track["artists"][0]["name"], track["title"], track["videoId"]
             )
             tracks.append(ytm_track)
         return tracks

--- a/streaming/streaming.py
+++ b/streaming/streaming.py
@@ -66,7 +66,7 @@ class StreamingService(object, metaclass=ABCMeta):
 class StreamingServiceTrack(metaclass=ABCMeta):
     def __str__(self):
         return (
-            f"{self.__class__.__name__}: '{self.title}' - {self.artist} "
+            f"{self.__class__.__name__}: {self.artist} - '{self.title}' "
             f"({self.id})"
         )
 
@@ -97,11 +97,11 @@ class StreamingServiceTrack(metaclass=ABCMeta):
     ARTIST_EXCLUDE_EXPRESSIONS = [r"\s\-\sTopic$"]
 
     @abstractproperty
-    def title(self):
+    def artist(self):
         raise NotImplementedError
 
     @abstractproperty
-    def artist(self):
+    def title(self):
         raise NotImplementedError
 
     @abstractproperty
@@ -135,7 +135,7 @@ class StreamingServiceTrack(metaclass=ABCMeta):
     @property
     def searchable_name(self):
         """Returns a name that can be used to search against other services"""
-        return f"{self.cleaned_title} - {self.cleaned_artist}".lower()
+        return f"{self.cleaned_artist} - {self.cleaned_title}".lower()
 
     @abstractmethod
     def share_link(self):

--- a/streaming/tests/integ/service/test_integ_spotify.py
+++ b/streaming/tests/integ/service/test_integ_spotify.py
@@ -11,13 +11,13 @@ class TestIntegSpotify(TestCase):
     def test_spotify_track_fetch(self):
         """Test ability to fetch tracks"""
         with Spotify() as spotify:
-            track = spotify.search_one_track("G.O.A.T. Polyphia")
-            self.assertEqual(track.title.lower(), "g.o.a.t.")
+            track = spotify.search_one_track("Polyphia G.O.A.T.")
             self.assertEqual(track.artist.lower(), "polyphia")
+            self.assertEqual(track.title.lower(), "g.o.a.t.")
 
             # trackId may change, not worth testing this
             trackId = spotify.get_trackId_from_url(track.share_link())
 
             track = spotify.get_track_from_trackId(trackId)
-            self.assertEqual(track.title.lower(), "g.o.a.t.")
             self.assertEqual(track.artist.lower(), "polyphia")
+            self.assertEqual(track.title.lower(), "g.o.a.t.")

--- a/streaming/tests/integ/service/test_integ_youtube.py
+++ b/streaming/tests/integ/service/test_integ_youtube.py
@@ -7,18 +7,18 @@ from ....service.youtube import YouTube, YouTubeTrack
 class TestIntegYouTube(TestCase):
     """Integration tests for YouTube"""
 
-    def _valid_searchable_names(self, artist, name):
+    def _valid_searchable_names(self, artist, title):
         for div in YouTubeTrack.SEARCHABLE_NAME_DIVIDERS:
             yield from [
-                f"{name} {div} {artist}".lower(),
-                f"{artist} {div} {name}".lower(),
+                f"{title} {div} {artist}".lower(),
+                f"{artist} {div} {title}".lower(),
             ]
 
     @pytest.mark.integ
     def test_youtube_track_fetch(self):
         """Test ability to fetch tracks"""
         with YouTube() as yt:
-            track = yt.search_one_track("G.O.A.T. Polyphia")
+            track = yt.search_one_track("Polyphia G.O.A.T.")
             self.assertIn(
                 track.searchable_name.lower(),
                 self._valid_searchable_names("Polyphia", "G.O.A.T."),

--- a/streaming/tests/integ/service/test_integ_ytmusic.py
+++ b/streaming/tests/integ/service/test_integ_ytmusic.py
@@ -19,4 +19,4 @@ class TestIntegYTMusic(TestCase):
             trackId = ytm.get_trackId_from_url(track.share_link())
 
             track = ytm.get_track_from_trackId(trackId)
-            self.assertEqual(track.searchable_name, "g.o.a.t. - polyphia")
+            self.assertEqual(track.searchable_name, "polyphia - g.o.a.t.")

--- a/streaming/tests/integ/service/test_integ_ytmusic.py
+++ b/streaming/tests/integ/service/test_integ_ytmusic.py
@@ -11,9 +11,9 @@ class TestIntegYTMusic(TestCase):
     def test_ytmusic_fetch(self):
         """Test ability to fetch tracks"""
         with YTMusic() as ytm:
-            track = ytm.search_one_track("G.O.A.T. Polyphia")
-            self.assertEqual(track.title.lower(), "g.o.a.t.")
+            track = ytm.search_one_track("Polyphia G.O.A.T.")
             self.assertEqual(track.artist.lower(), "polyphia")
+            self.assertEqual(track.title.lower(), "g.o.a.t.")
 
             # trackId may change, not worth testing this
             trackId = ytm.get_trackId_from_url(track.share_link())

--- a/streaming/tests/integ/test_integ_match.py
+++ b/streaming/tests/integ/test_integ_match.py
@@ -14,7 +14,7 @@ def test_get_similar_track_for_original_track():
     Use examples from prior failed cases.
     """
 
-    def _assert_matches_all_services(track_svc, title, artist):
+    def _assert_matches_all_services(track_svc, artist, title):
         if track_svc == Spotify:
             track_type = SpotifyTrack
         elif track_svc == YouTube:
@@ -24,7 +24,7 @@ def test_get_similar_track_for_original_track():
         else:
             track_type = match.SearchTrack
 
-        track = track_type(title, artist, None)
+        track = track_type(artist, title, None)
         similar_tracks = match.get_similar_tracks_for_original_track(
             track_svc, track
         )
@@ -38,26 +38,26 @@ def test_get_similar_track_for_original_track():
 
     # Spotify
 
-    _assert_matches_all_services(Spotify, "Blood Bank", "Bon Iver")
+    _assert_matches_all_services(Spotify, "Bon Iver", "Blood Bank")
 
     # YouTube
 
     _assert_matches_all_services(
-        YouTube, "Bon Iver - PDLIF - Official Video", "Bon Iver"
+        YouTube, "Bon Iver", "Bon Iver - PDLIF - Official Video"
     )
     # Video actually separates title and artist
     _assert_matches_all_services(
-        YouTube, "Patterns (Demo)", "Letters To The Editor - Topic"
+        YouTube, "Letters To The Editor - Topic", "Patterns (Demo)"
     )
 
     # YTMusic
 
     _assert_matches_all_services(
-        YTMusic, "Save Me (New Unreleased Video)", "Jelly Roll"
+        YTMusic, "Jelly Roll", "Save Me (New Unreleased Video)"
     )
 
     # Search
 
     _assert_matches_all_services(
-        None, "Jelly Roll - Save Me (New Unreleased Video)", None
+        None, None, "Jelly Roll - Save Me (New Unreleased Video)"
     )

--- a/tests/integ/test_integ_handler.py
+++ b/tests/integ/test_integ_handler.py
@@ -13,17 +13,52 @@ class TestIntegHandler(TestCase):
     """Integration tests for handler.py"""
 
     @pytest.mark.integ
-    def test_handle_webhook_update(self):
+    def test_handle_webhook_update_search(self):
+        """Integration test for handle_webhook_update method.
+
+        Posts message to TELEGRAM_CHAT_ID.
+        """
+        text = "@BopizTestBot volbeat - lola montez"
+        event = {
+            "body": json.dumps(
+                {
+                    "update_id": 10000,
+                    "message": {
+                        "date": 99999999999,
+                        "chat": {
+                            "last_name": "Test Lastname",
+                            "id": TELEGRAM_CHAT_ID,
+                            "first_name": "Test",
+                            "username": "Test",
+                        },
+                        "message_id": 1365,
+                        "from": {
+                            "last_name": "Test Lastname",
+                            "id": 1111111,
+                            "first_name": "Test",
+                            "username": "Test",
+                        },
+                        "text": text,
+                    },
+                }
+            )
+        }
+        response = handler.handle_webhook_update(event, None)
+        self.assertEqual(response["statusCode"], 200)
+
+    @pytest.mark.integ
+    def test_handle_webhook_update_mirror_links(self):
         """Integration test for handle_webhook_update method.
 
         Posts message to TELEGRAM_CHAT_ID.
         """
         text = (
             "handler.handle_webhook_update() integration test:\n"
-            "https://play.google.com/music/m/Tkqhlm2ssr4y2s76wfcjahkv3b4\n"
+            "https://play.google.com/music/m/Tkqhlm2ssr4y2s76wfcjahkv3b4\n"  # no longer supported
             "https://open.spotify.com/track/1wnq9TwifJ9ipLUFsm8vKx?si=IUytRONLTYWxJz3g5L9y8g\n"  # noqa: E501
             "https://youtu.be/_kvZpVMY89c\n"
-            "https://youtu.be/srre8i83vL8"  # non-music link
+            "https://youtu.be/srre8i83vL8\n"  # non-music link
+            "https://music.youtube.com/watch?v=xsKQdGkrqkw&feature=share"
         )
         event = {
             "body": json.dumps(


### PR DESCRIPTION
Swaps references in code to use `artist - title` convention instead of `title - artist`, which is less common.

Additionally fixes long-standing bug with index in YTMusic

Tickets:
https://trello.com/c/MhNHrMvh
https://trello.com/c/x3WPiPmt